### PR TITLE
fix: StringValue omitempty skips empty-wrapper fields

### DIFF
--- a/grpc/interceptor/validator.go
+++ b/grpc/interceptor/validator.go
@@ -44,11 +44,17 @@ func init() {
 	// Value string rather than the struct.
 	// NOTE: validator/v10 dereferences pointer fields before CustomTypeFunc
 	// lookup, so we must register for the struct type (not the pointer type).
+	// Return nil when the inner value is empty so that `omitempty` triggers:
+	// hasValue() treats a non-nil interface with "" as present (because
+	// fldIsPointer is set from the *StringValue pointer), which would run
+	// e.g. the `email` tag on an empty string and fail.
 	Validator.Validator.RegisterCustomTypeFunc(func(field reflect.Value) interface{} {
 		if sv, ok := field.Interface().(wrapperspb.StringValue); ok {
-			return sv.GetValue()
+			if v := sv.GetValue(); v != "" {
+				return v
+			}
 		}
-		return ""
+		return nil
 	}, wrapperspb.StringValue{})
 }
 

--- a/grpc/interceptor/validator_test.go
+++ b/grpc/interceptor/validator_test.go
@@ -1,0 +1,68 @@
+package interceptor_test
+
+import (
+	"testing"
+
+	"github.com/phogolabs/plex/grpc/interceptor"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type member struct {
+	Email *wrapperspb.StringValue `json:"email" validate:"omitempty,email"`
+	Phone *wrapperspb.StringValue `json:"phone" validate:"omitempty,e164"`
+}
+
+func TestValidator_StringValueWrapper(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *member
+		wantErr bool
+	}{
+		{
+			name:    "nil wrappers pass omitempty",
+			input:   &member{},
+			wantErr: false,
+		},
+		{
+			name: "empty-string wrappers pass omitempty",
+			input: &member{
+				Email: wrapperspb.String(""),
+				Phone: wrapperspb.String(""),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid email and e164 phone pass",
+			input: &member{
+				Email: wrapperspb.String("test@example.com"),
+				Phone: wrapperspb.String("+12125551234"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid email fails",
+			input: &member{
+				Email: wrapperspb.String("not-an-email"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-e164 phone fails",
+			input: &member{
+				Phone: wrapperspb.String("212-555-1234"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := interceptor.Validator.Validator.Struct(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- A `*wrapperspb.StringValue` field tagged `validate:"omitempty,<stringTag>"` (e.g. `omitempty,email`, `omitempty,e164`) still ran the inner tag when the wrapper held an empty string, failing validation for well-formed requests.
- The CustomTypeFunc registered in 00aec4c returned `""` for empty wrappers. Combined with `fldIsPointer=true` (set by validator/v10 when dereferencing the wrapper pointer), `hasValue()` treats a non-nil interface holding `""` as present, so `omitempty` never triggered and the inner tag ran on an empty string.
- Return `nil` from the CustomTypeFunc when the inner `Value` is empty so `omitempty` skips the field. Real (non-empty) values still unwrap to their inner string.

## Repro

```go
type Member struct {
    Email *wrapperspb.StringValue `validate:"omitempty,email"`
    Phone *wrapperspb.StringValue `validate:"omitempty,e164"`
}
// Before this fix: validating Member{Email: wrapperspb.String(""), Phone: wrapperspb.String("")}
// failed with "Field validation for 'email'/'phone' failed on the 'email'/'e164' tag".
// After: omitempty triggers and validation passes.
```

Hit in production against `members-api` when the web form submitted a member with only a phone number: the empty-string wrapper for `email` produced a 400 from the gRPC validator even though the user's phone was valid.

## Test plan

- [x] `go test ./grpc/interceptor/... -run TestValidator_StringValueWrapper -v` covers: nil wrappers, empty-string wrappers (the regression), valid data, invalid email, non-E.164 phone.
- [x] `go build ./...` across the module.